### PR TITLE
feat: improve stack distinction

### DIFF
--- a/packages/react-navigation-visualizer/webui/src/NavigationTree.tsx
+++ b/packages/react-navigation-visualizer/webui/src/NavigationTree.tsx
@@ -99,6 +99,15 @@ const LeafContainer = styled.div(({ theme: antdTheme }) => ({
   padding: 8,
 }));
 
+const SelectedLeafContainer = styled.div({
+  display: 'flex',
+  flex: 1,
+  padding: 4,
+  border: 'dashed',
+  borderRadius: 4,
+  borderWidth: 2,
+});
+
 const LeafTitle = styled(Typography.Text)({
   color: 'white',
 });
@@ -112,12 +121,15 @@ const Leaf = ({
   isSelectedTab?: boolean;
   color: string;
 }) => {
+  const Wrapper = isSelectedTab ? SelectedLeafContainer : React.Fragment;
   return (
-    <LeafContainer style={{ backgroundColor: color }}>
-      <LeafTitle style={{ textDecoration: isSelectedTab ? 'underline' : 'none' }}>
-        {title}
-      </LeafTitle>
-    </LeafContainer>
+    <Wrapper style={{ borderColor: color }}>
+      <LeafContainer style={{ backgroundColor: color }}>
+        <LeafTitle style={{ textDecoration: isSelectedTab ? 'underline' : 'none' }}>
+          {title}
+        </LeafTitle>
+      </LeafContainer>
+    </Wrapper>
   );
 };
 

--- a/packages/react-navigation-visualizer/webui/src/NavigationTree.tsx
+++ b/packages/react-navigation-visualizer/webui/src/NavigationTree.tsx
@@ -51,6 +51,7 @@ export function NavigationTree({ logs }: Props) {
       </Layout.Content>
       {hasCurrentItem ? (
         <Sidebar
+          Legend={<Legend />}
           action={currentNavigationItem.action}
           state={currentNavigationItem.state}
           stack={currentNavigationItem.stack}
@@ -221,4 +222,28 @@ const generateColor = (key: string) => {
   console.log(newColor);
 
   return newColor;
+};
+
+const Legend = () => {
+  return (
+    <div style={{ padding: 12 }}>
+      <NodeContainer style={{ borderColor: 'hsl(0, 70%, 50%)' }}>
+        <Leaf title="Screen" color="hsl(0, 70%, 50%)" />
+        <div style={{ height: 4 }} />
+        <NodeTitle style={{ color: 'hsl(0, 70%, 50%)' }}>Stack Navigator</NodeTitle>
+      </NodeContainer>
+      <div style={{ height: 12 }} />
+      <NodeContainer style={{ borderColor: 'hsl(0, 70%, 50%)' }}>
+        <div style={{ display: 'flex', flexDirection: 'row' }}>
+          <Leaf title="Unselected Tab" color="hsl(0, 70%, 50%)" />
+          <div style={{ width: 4 }} />
+          <SelectedLeafContainer style={{ borderColor: 'hsl(0, 70%, 50%)' }}>
+            <Leaf title="Selected Tab" color="hsl(0, 70%, 50%)" />
+          </SelectedLeafContainer>
+        </div>
+        <div style={{ height: 4 }} />
+        <NodeTitle style={{ color: 'hsl(0, 70%, 50%)' }}>Tab Navigator</NodeTitle>
+      </NodeContainer>
+    </div>
+  );
 };

--- a/packages/react-navigation-visualizer/webui/src/NavigationTree.tsx
+++ b/packages/react-navigation-visualizer/webui/src/NavigationTree.tsx
@@ -126,7 +126,11 @@ const NodeContainer = styled.div(({ theme: antdTheme }) => ({
   borderWidth: 1,
   border: 'solid',
   borderColor: antdTheme.token?.colorPrimary,
+  borderTopWidth: 0,
+  borderTopLeftRadius: 0,
+  borderTopRightRadius: 0,
   padding: 8,
+  paddingTop: 4,
 }));
 
 const NodeTitle = styled(Typography)(({ theme }) => ({

--- a/packages/react-navigation-visualizer/webui/src/NavigationTree.tsx
+++ b/packages/react-navigation-visualizer/webui/src/NavigationTree.tsx
@@ -188,7 +188,7 @@ const generateColor = (key: string) => {
     return colorMap[key];
   }
 
-  currentHue = (currentHue + 9) % 360;
+  currentHue = (currentHue + 15) % 360;
   const newColor = `hsl(${currentHue}, 70%, 50%)`;
 
   colorMap[key] = newColor;

--- a/packages/react-navigation-visualizer/webui/src/NavigationTree.tsx
+++ b/packages/react-navigation-visualizer/webui/src/NavigationTree.tsx
@@ -86,10 +86,12 @@ const HalfContent = styled.div({
 
 const Spacer = styled.div({
   height: 4,
+  width: 4,
 });
 
 const LeafContainer = styled.div(({ theme: antdTheme }) => ({
   display: 'flex',
+  flex: 1,
   backgroundColor: antdTheme.token?.colorPrimary,
   borderRadius: 4,
   alignItems: 'center',
@@ -138,6 +140,14 @@ const NodeTitle = styled(Typography)(({ theme }) => ({
   alignSelf: 'flex-start',
 }));
 
+const TabContainer = styled.div({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-around',
+});
+
 const Node = ({
   name,
   state,
@@ -154,25 +164,28 @@ const Node = ({
 
   const color = generateColor(state.key);
 
+  const StackWrapper = state.type === 'tab' ? TabContainer : React.Fragment;
+
   return (
     <NodeContainer style={{ borderColor: color }}>
-      {routes.toReversed().map((route, index) => (
-        <React.Fragment key={index}>
-          {route.state?.routes && route.state.routes.length ? (
-            <Node name={route.name} state={route.state} parentColor={color} />
-          ) : (
-            <Leaf
-              title={route.name}
-              isSelectedTab={
-                state.type === 'tab' && state.index === state.routes.length - 1 - index
-              }
-              color={color}
-            />
-          )}
-          <Spacer />
-        </React.Fragment>
-      ))}
-      <Spacer />
+      <StackWrapper>
+        {routes.toReversed().map((route, index) => (
+          <React.Fragment key={index}>
+            {route.state?.routes && route.state.routes.length ? (
+              <Node name={route.name} state={route.state} parentColor={color} />
+            ) : (
+              <Leaf
+                title={route.name}
+                isSelectedTab={
+                  state.type === 'tab' && state.index === state.routes.length - 1 - index
+                }
+                color={color}
+              />
+            )}
+            {index < routes.length - 1 ? <Spacer /> : null}
+          </React.Fragment>
+        ))}
+      </StackWrapper>
       <NodeTitle style={{ color }}>{name}</NodeTitle>
     </NodeContainer>
   );

--- a/packages/react-navigation-visualizer/webui/src/Sidebar.tsx
+++ b/packages/react-navigation-visualizer/webui/src/Sidebar.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
-import ReactJson from 'react-json-view';
 import { Layout } from 'antd';
+import ReactJson from 'react-json-view';
 
 import * as React from 'react';
 
@@ -11,10 +11,12 @@ export function Sidebar({
   action,
   state,
   stack,
+  Legend,
 }: {
   action: object;
   state: object | undefined;
   stack?: string | undefined;
+  Legend?: React.ReactNode;
 }) {
   return (
     <Layout.Sider
@@ -25,7 +27,7 @@ export function Sidebar({
         padding: `0 ${theme.space.small}px`,
         borderRadius: theme.borderRadius,
         overflow: 'auto',
-        height: '100vh'
+        height: '100vh',
       }}>
       {stack ? (
         <>
@@ -77,6 +79,12 @@ export function Sidebar({
           </Code>
         </>
       ) : null}
+      {Legend && (
+        <>
+          <Title4>Legend</Title4>
+          {Legend}
+        </>
+      )}
       <Title4>Action</Title4>
       <ReactJson src={action} collapsed />
       <Title4>State</Title4>


### PR DESCRIPTION
# Why
User needs to be able to distinguish easily Stacks and Tabs

# How
- Increased distance between colors in the Stacks
- Removed the top border of the Stacks
- Display Tabs as horizontal Stacks
- Show selected Tab
- Add a legend

<img width="1512" alt="Capture d’écran 2024-12-13 à 15 08 03" src="https://github.com/user-attachments/assets/f0f54b4d-ae6f-4ef2-853f-1428f198eb74" />
