### PR TITLE
fix: put back root layout

### DIFF
--- a/packages/react-navigation-visualizer/package.json
+++ b/packages/react-navigation-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bam.tech/react-navigation-visualizer-dev-plugin",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Visualization Tool based on Expo DevTools Plugin for React Navigation",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/react-navigation-visualizer/webui/src/NavigationTree/NavigationTree.tsx
+++ b/packages/react-navigation-visualizer/webui/src/NavigationTree/NavigationTree.tsx
@@ -61,10 +61,10 @@ export function NavigationTree({ logs }: Props) {
               <Typography>Navigation state n°{logs.length - index}</Typography>
               <Spacer />
               <HalfContent>
-                {log.state && log.state.routes[0] && log.state.routes[0].state && (
+                {log.state && (
                   <NavigationNode
-                    name={log.state.routes[0].name}
-                    state={log.state.routes[0].state}
+                    name="root"
+                    state={log.state}
                     parentColor={generateColor(log.state.key)}
                     isParamsVisible={isParamsVisible}
                   />


### PR DESCRIPTION
## What was done
Revert [this commit](https://github.com/bamlab/dev-plugins/pull/18/commits/804b779b25b521a7678e8a4748188ac4664cf383). Indeed, with react-navigation, the root navigator is in fact the root of the JSON Object. Not having a root stack displayed leads to showing only the first element of the root navigator.

To do : find a way to distinguish if the root layout is necessary or not (maybe look at the name of the stack just below, which seems to be named "__root" in expo-router