### PR TITLE
fix: fix type error when using react navigation ref with expo-router 55.0.13

### DIFF
--- a/packages/react-navigation-visualizer/src/useReactNavigationDevTools.ts
+++ b/packages/react-navigation-visualizer/src/useReactNavigationDevTools.ts
@@ -1,13 +1,17 @@
-import type { NavigationContainerRefWithCurrent } from '@react-navigation/core';
 import { useReduxDevToolsExtension } from '@react-navigation/devtools';
 import { useDevToolsPluginClient, type EventSubscription } from 'expo/devtools';
 import { useEffect, useRef } from 'react';
 
 import { ReduxExtensionAdapter } from './ReduxExtensionAdapter';
 
-export function useReactNavigationDevTools<T extends object = any>(
-  ref: NavigationContainerRefWithCurrent<T>
-) {
+type NavigationContainerRef = {
+  current: object | null;
+};
+
+/**
+ * @param ref - The ref returned by `useNavigationContainerRef()` from `expo-router` or `@react-navigation/native`
+ */
+export function useReactNavigationDevTools(ref: NavigationContainerRef) {
   const client = useDevToolsPluginClient('react-navigation');
   const adapterRef = useRef(new ReduxExtensionAdapter());
   // @ts-ignore: Override global


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="739" height="312" alt="Capture d’écran 2026-04-30 à 17 52 15" src="https://github.com/user-attachments/assets/b498d13a-7e9f-4282-8f5b-5678ba31b8a3" /> | <img width="497" height="121" alt="Capture d’écran 2026-04-30 à 17 53 08" src="https://github.com/user-attachments/assets/4f720379-ca30-480e-ac6c-0bee4143df0d" /> |

### What was done
Removed extensive typing from `@react-navigation/core`, replaced by a description of the params.

### Why
Since `@react-navigation/core` types are changing regularly, we often face type mismatches between the dev's version and the version used by `@react-navigation/devtools`. Since we want to support as many navigation library versions as possible, we lower the type expectations, as it is already bypassed by some catches in `useReactNavigationDevTools`